### PR TITLE
Fix in CI and json annottations

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,7 +51,7 @@ jobs:
     executor: maven
     steps:
       - checkout:
-          path: ~/java-logger
+          path: ~/unified-content-model
       - run:
           name: Publish Tag to Nexus repository
           command: |

--- a/model/src/main/java/com/ft/api/ucm/model/v1/AspectSetAware.java
+++ b/model/src/main/java/com/ft/api/ucm/model/v1/AspectSetAware.java
@@ -1,9 +1,11 @@
 package com.ft.api.ucm.model.v1;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import java.util.List;
 
 public interface AspectSetAware {
 
+  @JsonIgnore
   void setAspectSet(String aspectSetName);
 
   void setAspects(List<String> aspectNames);

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,6 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<spring.version>5.3.9</spring.version>
 		<spring.boot.version>2.5.3</spring.boot.version>
-		<spring.ws.version>5.3.9</spring.ws.version>
 		<servlet-api.version>4.0.1</servlet-api.version>
 		<javax.annotation-api.version>1.3.2</javax.annotation-api.version>
 		<java.version>11</java.version>


### PR DESCRIPTION
# Description

- Avoid duplicate aspectSet from AspectSetAware
- Fix folder for mvn release pipeline in CI

## What

Without this, the serialized json will contains a duplicate `aspectSet` key, [this](https://github.com/Financial-Times/content-search-api-port/blob/857ee4d348a055b38b920595553a77a635c53eca/ws/src/test/java/com/ft/search/platform/api/rs/marshalling/SearchResponseJsonSerializationTest.java#L62) test (using data from [here](https://github.com/Financial-Times/content-search-api-port/blob/857ee4d348a055b38b920595553a77a635c53eca/ws/src/test/resources/com/ft/search/platform/api/ws/marshalling/expectedSearchResponse.json#L26)) fails.

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Breaking change
- [x] Minor change (e.g. fixing a typo, adding config)

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
