### PR TITLE
Fix checkout path for release publishing step ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,7 +51,6 @@ jobs:
     executor: maven
     steps:
       - checkout:
-          path: ~/java-logger
       - run:
           name: Publish Tag to Nexus repository
           command: |


### PR DESCRIPTION
# Description

## What

Fix checkout path for release publishing step ci

## Why

https://app.circleci.com/pipelines/github/Financial-Times/unified-content-model/18/workflows/47b79645-e267-4fc5-8434-797f50293a00/jobs/21

```
[INFO] 
[INFO] ------------------< org.apache.maven:standalone-pom >-------------------
[INFO] Building Maven Stub Project (No POM) 1
[INFO] --------------------------------[ pom ]---------------------------------
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  14.824 s
[INFO] Finished at: 2021-09-23T09:42:00Z
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.codehaus.mojo:versions-maven-plugin:2.8.1:set (default-cli): Goal requires a project to execute but there is no POM in this directory (/root/unified-content-model). Please verify you invoked Maven from the correct directory. -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MissingProjectException

Exited with code exit status 1
CircleCI received exit code 1
```

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Breaking change
- [ ] Minor change (e.g. fixing a typo, adding config)

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
